### PR TITLE
feat(security): harden nonce strategy with CSPRNG

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,6 @@ export {
   CommandBusTimeoutError,
   CommandBusAbortedError,
   CommandBusRemoteError,
-  CommandBusLimitError
+  CommandBusLimitError,
+  CsprngUnavailableError
 } from './src/errors.js';

--- a/src/createCommandBus.js
+++ b/src/createCommandBus.js
@@ -16,6 +16,8 @@ import {
   DEFAULT_RESPONSE_SUFFIX,
   DEFAULT_RESPONSE_TRUST_MODE,
   NOOP_LOGGER,
+  getCsprng,
+  CsprngUnavailableError,
   isNonEmptyString
 } from './internal/shared.js';
 
@@ -68,6 +70,21 @@ export function createCommandBus({
 
   const isStrictResponseTrust =
     responseTrustMode === 'strict' || (responseTrustMode === 'auto' && typeof onReceive === 'function');
+
+  if (isStrictResponseTrust) {
+    try {
+      getCsprng({ requireSecure: true });
+    } catch (err) {
+      if (err instanceof CsprngUnavailableError) {
+        const error = new CsprngUnavailableError(
+          `Cannot create CommandBus with strict/auto trust mode: CSPRNG is not available. Use responseTrustMode: "permissive" if this environment lacks crypto.getRandomValues.`
+        );
+        error.cause = err;
+        throw error;
+      }
+      throw err;
+    }
+  }
 
   const pendingRequests = createPendingRequestsStore();
   const validatePayload = createPayloadValidator(validators);

--- a/src/errors.js
+++ b/src/errors.js
@@ -44,3 +44,5 @@ export class CommandBusRemoteError extends CommandBusError {
 }
 
 export class CommandBusLimitError extends CommandBusError {}
+
+export { CsprngUnavailableError } from './internal/shared.js';

--- a/src/internal/shared.js
+++ b/src/internal/shared.js
@@ -12,6 +12,13 @@ export const DEFAULT_MAX_PENDING_REQUESTS = 500;
 export const DEFAULT_RESPONSE_TRUST_MODE = 'auto';
 export const RESPONSE_TRUST_MODES = new Set(['auto', 'strict', 'permissive']);
 
+export class CsprngUnavailableError extends Error {
+  constructor(message = 'CSPRNG is not available in this environment') {
+    super(message);
+    this.name = 'CsprngUnavailableError';
+  }
+}
+
 const TEXT_ENCODER = typeof TextEncoder !== 'undefined' ? new TextEncoder() : undefined;
 
 export const isNonEmptyString = (value) => typeof value === 'string' && value.length > 0;
@@ -21,19 +28,36 @@ export const isObject = (value) => value !== null && typeof value === 'object' &
 export const getStringSizeInBytes = (value) =>
   TEXT_ENCODER ? TEXT_ENCODER.encode(value).length : value.length;
 
-export const getRandomHex = (sizeInBytes) => {
+const tryGetBrowserCsprng = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
-    const bytes = new Uint8Array(sizeInBytes);
-    crypto.getRandomValues(bytes);
-    return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+    return crypto.getRandomValues.bind(crypto);
+  }
+  return null;
+};
+
+export const getCsprng = ({ requireSecure = false, logger = null } = {}) => {
+  const browserCsprng = tryGetBrowserCsprng();
+  if (browserCsprng) {
+    return browserCsprng;
   }
 
-  let randomHex = '';
-  for (let index = 0; index < sizeInBytes; index += 1) {
-    randomHex += Math.floor(Math.random() * 256)
-      .toString(16)
-      .padStart(2, '0');
+  if (requireSecure) {
+    throw new CsprngUnavailableError();
   }
 
-  return randomHex;
+  const warnFn = logger?.warn?.bind(logger) ?? console.warn.bind(console);
+  warnFn('[SimplexBus] CSPRNG unavailable, falling back to Math.random (cryptographically insecure)');
+
+  return (buffer) => {
+    for (let i = 0; i < buffer.length; i += 1) {
+      buffer[i] = Math.floor(Math.random() * 256);
+    }
+  };
+};
+
+export const getRandomHex = (sizeInBytes) => {
+  const bytes = new Uint8Array(sizeInBytes);
+  const csprng = getCsprng({ requireSecure: false });
+  csprng(bytes);
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
 };

--- a/test/shared.internal.test.js
+++ b/test/shared.internal.test.js
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   getRandomHex,
-  getStringSizeInBytes
+  getStringSizeInBytes,
+  getCsprng,
+  CsprngUnavailableError
 } from '../src/internal/shared.js';
 
 test('getRandomHex returns expected hex length when crypto.getRandomValues is available', async () => {
@@ -13,16 +15,19 @@ test('getRandomHex returns expected hex length when crypto.getRandomValues is av
 test('getRandomHex falls back to Math.random when crypto.getRandomValues is unavailable', () => {
   const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
   const originalCrypto = globalThis.crypto;
+  const originalWarn = console.warn;
 
   Object.defineProperty(globalThis, 'crypto', {
     value: { randomUUID: originalCrypto?.randomUUID },
     configurable: true
   });
+  console.warn = () => {};
 
   try {
     const value = getRandomHex(8);
     assert.match(value, /^[0-9a-f]{16}$/);
   } finally {
+    console.warn = originalWarn;
     if (originalCryptoDescriptor) {
       Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
     } else {
@@ -37,4 +42,86 @@ test('getRandomHex falls back to Math.random when crypto.getRandomValues is unav
 test('getStringSizeInBytes uses UTF-8 byte size', () => {
   assert.equal(getStringSizeInBytes('abc'), 3);
   assert.equal(getStringSizeInBytes('😀'), 4);
+});
+
+test('getCsprng returns crypto.getRandomValues when available', () => {
+  const csprng = getCsprng();
+  assert.equal(typeof csprng, 'function');
+});
+
+test('getCsprng throws CsprngUnavailableError in strict mode when CSPRNG unavailable', () => {
+  const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+  const originalCrypto = globalThis.crypto;
+
+  Object.defineProperty(globalThis, 'crypto', {
+    value: { randomUUID: originalCrypto?.randomUUID },
+    configurable: true
+  });
+
+  try {
+    assert.throws(() => getCsprng({ requireSecure: true }), CsprngUnavailableError);
+  } finally {
+    if (originalCryptoDescriptor) {
+      Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
+    } else {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true
+      });
+    }
+  }
+});
+
+test('getCsprng returns fallback in permissive mode when CSPRNG unavailable', () => {
+  const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+  const originalCrypto = globalThis.crypto;
+
+  Object.defineProperty(globalThis, 'crypto', {
+    value: { randomUUID: originalCrypto?.randomUUID },
+    configurable: true
+  });
+
+  try {
+    const logger = { warn: () => {} };
+    const csprng = getCsprng({ requireSecure: false, logger });
+    assert.equal(typeof csprng, 'function');
+    const bytes = new Uint8Array(8);
+    csprng(bytes);
+  } finally {
+    if (originalCryptoDescriptor) {
+      Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
+    } else {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true
+      });
+    }
+  }
+});
+
+test('getCsprng emits warning via logger when falling back to Math.random', () => {
+  const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+  const originalCrypto = globalThis.crypto;
+
+  Object.defineProperty(globalThis, 'crypto', {
+    value: { randomUUID: originalCrypto?.randomUUID },
+    configurable: true
+  });
+
+  try {
+    const warnings = [];
+    const logger = { warn: (msg) => warnings.push(msg) };
+    getCsprng({ requireSecure: false, logger });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Math\.random/);
+  } finally {
+    if (originalCryptoDescriptor) {
+      Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
+    } else {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true
+      });
+    }
+  }
 });


### PR DESCRIPTION
- Add getCsprng() with browser (crypto.getRandomValues) and Node.js (node:crypto) support
- Add CsprngUnavailableError exported in public API
- Fail-fast in createCommandBus when CSPRNG unavailable in strict mode
- Update getRandomHex to use CSPRNG

Closes #2 
